### PR TITLE
When splitting don't give any cards to the 2nd hand

### DIFF
--- a/best_move.py
+++ b/best_move.py
@@ -359,8 +359,8 @@ def perfect_mover(cards: tuple[int, ...], dealer_up_card: int, cards_not_seen: t
                                                      dealer_stands_soft_17)[0]
                                ) * (probabilities[card])
                 elif max_splits == 1:
-                    profit_split = 0
-                    profit_no_split = 0
+                    profit_split = 0.
+                    profit_no_split = 0.
                     profit_split += (perfect_mover_cache((cards[0], card), dealer_up_card,
                                                          create_deck_from_counts_cache(counts_copy), can_double and das,
                                                          False, False, 1,
@@ -450,7 +450,7 @@ def perfect_mover(cards: tuple[int, ...], dealer_up_card: int, cards_not_seen: t
                                                                      dealer_stands_soft_17)[0]
                                                ) * (probabilities[card] * probabilities_copy[card2] * probabilities[card3])
                         else:  # Can split the first hand.
-                            profit_no_split = 0
+                            profit_no_split = 0.
                             profit_split = (perfect_mover_cache((cards[0],), dealer_up_card,
                                                                 create_deck_from_counts_cache(counts_copy2),
                                                                 can_double and das,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ author = 'Ioannis Pantidis'
 extensions = ['sphinx.ext.autodoc']
 
 templates_path = ['_templates']
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 autodoc_typehints = "description"
 

--- a/expected_value.py
+++ b/expected_value.py
@@ -200,9 +200,12 @@ def play_hand(action_class: action_strategies.BaseMover,
             hand2 = Hand([hand.cards[1]])
             card1 = get_card_from_shoe(shoe)
             hand1.add_card(card1)
+            done_hands.extend(play_hand(action_class, [hand1.cards],
+                                        dealer_up_card, dealer_down_card, shoe, splits_remaining - 1, deck_number,
+                                        dealer_peeks_for_blackjack, das, dealer_stands_soft_17))
             card2 = get_card_from_shoe(shoe)
             hand2.add_card(card2)
-            done_hands.extend(play_hand(action_class, [hand1.cards, hand2.cards] + hand_cards[hand_index + 1:],
+            done_hands.extend(play_hand(action_class, [hand2.cards] + hand_cards[hand_index + 1:],
                                         dealer_up_card, dealer_down_card, shoe, splits_remaining - 1, deck_number,
                                         dealer_peeks_for_blackjack, das, dealer_stands_soft_17))
             break
@@ -333,10 +336,12 @@ def simulate_hand(action_class: action_strategies.BaseMover,
             return split_profit + insurance_profit
         card1 = get_card_from_shoe(shoe)
         hand1.add_card(card1)
-        card2 = get_card_from_shoe(shoe)
-        hand2.add_card(card2)
         all_hands = play_hand(action_class, [hand1.cards, hand2.cards], dealer_up_card, dealer_down_card, shoe,
                               splits_remaining - 1, deck_number, dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
+        card2 = get_card_from_shoe(shoe)
+        hand2.add_card(card2)
+        all_hands += play_hand(action_class, [hand2.cards], dealer_up_card, dealer_down_card, shoe,
+                               splits_remaining - 1, deck_number, dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
         if player_loses_all_bets:
             return -len(all_hands) + insurance_profit
         dealer_value = play_dealer((dealer_up_card, dealer_down_card), shoe, dealer_stands_soft_17)

--- a/test/test_best_move.py
+++ b/test/test_best_move.py
@@ -10,8 +10,8 @@ def test_best_move() -> None:
     for card in [11, 11, 11]:
         shoe.remove(card)
     results = perfect_mover_cache((11, 11), 11, tuple(shoe), max_splits=1, return_all_profits=True)
-    assert results == (-0.6664582487827273, -0.022205703672547265, -0.6202385156597964, 0.12714379565459186, -0.5,
+    assert results == (-0.6664582487827273, -0.022205703672547265, -0.6202385156597964, 0.1271437956545917, -0.5,
                        -0.033980582524271885)
 
     results = perfect_mover_cache((10, 10), 10, tuple(shoe), max_splits=2, return_all_profits=True)
-    assert results == (0.5542589949582133, -0.8662002899228858, -1.7324005798457716, 0.03264991092613637, -0.5, -1000.0)
+    assert results == (0.5542589949582133, -0.8662002899228858, -1.7324005798457716, 0.03259440081835285, -0.5, -1000.0)


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

When splitting a hand we play the first hand untilt the end and then play the second one. Currently, both hands would get a card and only after that would we play the first hnd until the end.

## Related Issues:

#5 

## Checklist:

- [x] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots (if applicable):
