### PR TITLE
Fix bug where the player would bet after being dealt the cards

### DIFF
--- a/expected_value.py
+++ b/expected_value.py
@@ -203,16 +203,17 @@ def play_hand(action_class: action_strategies.BaseMover,
             hand2 = Hand([hand.cards[1]])
             card1 = get_card_from_shoe(shoe)
             hand1.add_card(card1)
-            done_split_hands, splits_used_first_hand = play_hand(action_class, [hand1.cards],
-                                        dealer_up_card, dealer_down_card, shoe, splits_remaining - 1, deck_number,
-                                        dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
+            done_split_hands, splits_used_first_hand = play_hand(action_class, [hand1.cards], dealer_up_card,
+                                                                 dealer_down_card, shoe, splits_remaining - 1, deck_number,
+                                                                 dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
             done_hands.extend(done_split_hands)
             splits_used += splits_used_first_hand
             card2 = get_card_from_shoe(shoe)
             hand2.add_card(card2)
             done_split_hands, splits_used_second_hand = play_hand(action_class, [hand2.cards] + hand_cards[hand_index + 1:],
-                                        dealer_up_card, dealer_down_card, shoe, splits_remaining - splits_used, deck_number,
-                                        dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
+                                                                  dealer_up_card, dealer_down_card, shoe,
+                                                                  splits_remaining - splits_used, deck_number,
+                                                                  dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
             done_hands.extend(done_split_hands)
             splits_used += splits_used_second_hand
             break
@@ -310,9 +311,9 @@ def simulate_hand(action_class: action_strategies.BaseMover,
             return -1 + insurance_profit
         if hand.value() > 21:
             return -1 + insurance_profit
-        hand_cards, _ = play_hand(action_class, [hand.cards], dealer_up_card, dealer_down_card, shoe,
-                                  splits_remaining, deck_number, dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
-        hand = Hand(hand_cards[0])
+        hands, _ = play_hand(action_class, [hand.cards], dealer_up_card, dealer_down_card, shoe,
+                             splits_remaining, deck_number, dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
+        hand = Hand(hands[0])
         dealer_value = play_dealer((dealer_up_card, dealer_down_card), shoe, dealer_stands_soft_17)
         if hand.value() > 21 or dealer_value > hand.value():
             return -1 + insurance_profit
@@ -344,7 +345,8 @@ def simulate_hand(action_class: action_strategies.BaseMover,
         card1 = get_card_from_shoe(shoe)
         hand1.add_card(card1)
         all_hands, splits_used = play_hand(action_class, [hand1.cards], dealer_up_card, dealer_down_card, shoe,
-                              splits_remaining - 1, deck_number, dealer_peeks_for_blackjack, das, dealer_stands_soft_17)
+                                           splits_remaining - 1, deck_number, dealer_peeks_for_blackjack, das,
+                                           dealer_stands_soft_17)
         card2 = get_card_from_shoe(shoe)
         hand2.add_card(card2)
         done_hands, _ = play_hand(action_class, [hand2.cards], dealer_up_card, dealer_down_card, shoe,

--- a/shoe_generators.py
+++ b/shoe_generators.py
@@ -12,6 +12,8 @@ def hilo_generator(true_count: int, decks: int, deck_penetration: float, cards_p
     :param deck_penetration: When to reshuffle the shoe. Reshuffles when cards remaining < starting cards * deck penetration.
         So the cards in the returned shoe must be at least starting cards * deck penetration.
     :param cards_present: The cards we have already seen, so that we don't get shoe with more cards of one type than possible.
+        For example, if the player was dealt 3 and 5, and the dealer's up card is a 3, then for 6 decks the maximum possible
+        number of 3s is 6*4-2=22.
     :return: A shoe with a specific true count.
     """
     max_true_count = true_count + .3 if true_count >= 0 else true_count


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

There was a bug where the player would bet after being dealt the cards. The player wouldn't use the cards to adjust their bet according to the specific EV of this combination, but rather it affected the calculation of the true count which affected the bet.

It also includes some minor fixes for splitting, and improves the calculation of the risk of ruin.

## Related Issues:

#7 
A lot of thanks to @bjwxh, who discovered the issue and found the cause of the bug.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots (if applicable):
