### PR TITLE
Improve risk of ruin calculation

### DIFF
--- a/expected_value.py
+++ b/expected_value.py
@@ -441,7 +441,7 @@ def expected_value(action_class: action_strategies.BaseMover, betting_class: bet
 
     risk_of_ruin_count = 0
     total_sims = len(profits_over_time_hand)
-    deque_min = deque()
+    deque_min: deque[int] = deque()
     for index, profit in enumerate(profits_over_time_hand):
         while deque_min and deque_min[0] < index - hands_played + 1:
             deque_min.popleft()


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Improves risk of ruin calculator by taking the chance of going bankrupt at any point during the run, not only after `hands_played` hands.

## Related Issues:

None.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots (if applicable):
